### PR TITLE
fix: change initial_prompt log from debug to info level

### DIFF
--- a/wyoming_mlx_whisper/handler.py
+++ b/wyoming_mlx_whisper/handler.py
@@ -106,7 +106,7 @@ class WhisperEventHandler(AsyncEventHandler):
             if transcribe.context:
                 self._initial_prompt = transcribe.context.get("initial_prompt")
                 if self._initial_prompt:
-                    _LOGGER.debug("Using initial prompt: %s", self._initial_prompt)
+                    _LOGGER.info("Using initial prompt: %s", self._initial_prompt)
             _LOGGER.debug("Transcribe event")
             return True
 


### PR DESCRIPTION
Makes the initial_prompt log message visible without --debug flag.