### PR TITLE
Expose initial_prompt via CLI and env

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Uses [`mlx-community/whisper-large-v3-turbo`](https://huggingface.co/mlx-communi
 | [`mlx-community/whisper-large-v3-turbo-q4`](https://huggingface.co/mlx-community/whisper-large-v3-turbo-q4) | 464 MB | ⚡⚡ Near real-time | Near-best |
 
 Use `--model <name>` to select a different model.
+Use `--initial-prompt <text>` to guide recognition with custom vocabulary.
 
 <details><summary><b><u>[ToC]</u></b> 📚</summary>
 
@@ -124,6 +125,8 @@ tail -f ~/Library/Logs/wyoming-mlx-whisper/*.log
 │                                     [default: mlx-community/whisper-large-v3-turbo]    │
 │ --language                    TEXT  Language code (e.g., 'en')                         │
 │                                     [env var: WHISPER_LANGUAGE]                        │
+│ --initial-prompt              TEXT  Initial prompt to guide Whisper recognition        │
+│                                     [env var: WHISPER_INITIAL_PROMPT]                  │
 │ --debug         --no-debug          Log DEBUG messages  [env var: WHISPER_DEBUG]       │
 │                                     [default: no-debug]                                │
 │ --version                           Print version and exit                             │

--- a/README.md
+++ b/README.md
@@ -117,20 +117,21 @@ tail -f ~/Library/Logs/wyoming-mlx-whisper/*.log
  Run the Wyoming MLX Whisper server.
 
 ╭─ Options ──────────────────────────────────────────────────────────────────────────────╮
-│ --uri                         TEXT  unix:// or tcp://                                  │
-│                                     [env var: WHISPER_URI]                             │
-│                                     [default: tcp://0.0.0.0:10300]                     │
-│ --model                       TEXT  Name of MLX Whisper model to use                   │
-│                                     [env var: WHISPER_MODEL]                           │
-│                                     [default: mlx-community/whisper-large-v3-turbo]    │
-│ --language                    TEXT  Language code (e.g., 'en')                         │
-│                                     [env var: WHISPER_LANGUAGE]                        │
-│ --initial-prompt              TEXT  Initial prompt to guide Whisper recognition        │
-│                                     [env var: WHISPER_INITIAL_PROMPT]                  │
-│ --debug         --no-debug          Log DEBUG messages  [env var: WHISPER_DEBUG]       │
-│                                     [default: no-debug]                                │
-│ --version                           Print version and exit                             │
-│ --help      -h                      Show this message and exit.                        │
+│ --uri                               TEXT  unix:// or tcp://                            │
+│                                           [env var: WHISPER_URI]                       │
+│                                           [default: tcp://0.0.0.0:10300]               │
+│ --model                             TEXT  Name of MLX Whisper model to use             │
+│                                           [env var: WHISPER_MODEL]                     │
+│                                           [default:                                    │
+│                                           mlx-community/whisper-large-v3-turbo]        │
+│ --language                          TEXT  Language code (e.g., 'en')                   │
+│                                           [env var: WHISPER_LANGUAGE]                  │
+│ --initial-prompt                    TEXT  Initial prompt to guide Whisper recognition  │
+│                                           [env var: WHISPER_INITIAL_PROMPT]            │
+│ --debug               --no-debug          Log DEBUG messages  [env var: WHISPER_DEBUG] │
+│                                           [default: no-debug]                          │
+│ --version                                 Print version and exit                       │
+│ --help            -h                      Show this message and exit.                  │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 ```

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -107,6 +107,28 @@ class TestWhisperEventHandler:
         assert handler._audio == b""
         assert handler._initial_prompt is None
 
+    def test_reset_restores_configured_initial_prompt(
+        self,
+        mock_wyoming_info: Info,
+        mock_model: str,
+    ) -> None:
+        """Test reset restores the startup initial prompt."""
+        handler = WhisperEventHandler(
+            mock_wyoming_info,
+            mock_model,
+            language=None,
+            initial_prompt="Default vocabulary",
+            reader=MagicMock(),
+            writer=MagicMock(),
+        )
+        handler._audio = b"some audio data"
+        handler._initial_prompt = "request vocabulary"
+
+        handler._reset()
+
+        assert handler._audio == b""
+        assert handler._initial_prompt == "Default vocabulary"
+
     @pytest.mark.asyncio
     async def test_handle_audio_chunk(self, handler: WhisperEventHandler) -> None:
         """Test handling of audio chunks."""
@@ -241,6 +263,31 @@ class TestWhisperEventHandler:
         assert result == "transcribed text"
         call_args = mock_mlx.transcribe.call_args
         assert call_args.kwargs["initial_prompt"] == "Custom vocabulary hint"
+
+    @pytest.mark.asyncio
+    async def test_transcribe_with_configured_initial_prompt(
+        self,
+        mock_wyoming_info: Info,
+        mock_model: str,
+    ) -> None:
+        """Test that _transcribe passes the startup initial_prompt when set."""
+        handler = WhisperEventHandler(
+            mock_wyoming_info,
+            mock_model,
+            language=None,
+            initial_prompt="Default vocabulary hint",
+            reader=MagicMock(),
+            writer=MagicMock(),
+        )
+        audio = np.zeros(16000, dtype=np.float32)
+
+        with patch("wyoming_mlx_whisper.handler.mlx_whisper") as mock_mlx:
+            mock_mlx.transcribe.return_value = {"text": "transcribed text"}
+            result = handler._transcribe(audio)
+
+        assert result == "transcribed text"
+        call_args = mock_mlx.transcribe.call_args
+        assert call_args.kwargs["initial_prompt"] == "Default vocabulary hint"
 
     @pytest.mark.asyncio
     async def test_handle_unknown_event(self, handler: WhisperEventHandler) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,6 +47,7 @@ class TestCLI:
         assert "Wyoming MLX Whisper" in output
         assert "--uri" in output
         assert "--model" in output
+        assert "--initial-prompt" in output
 
     def test_version_option(self, runner: CliRunner) -> None:
         """Test that --version works."""
@@ -71,6 +72,8 @@ class TestCLI:
                     "test-model",
                     "--language",
                     "en",
+                    "--initial-prompt",
+                    "Custom vocabulary",
                 ],
             )
 
@@ -80,6 +83,7 @@ class TestCLI:
             assert call_args[0][0] == "tcp://localhost:9999"  # uri
             assert call_args[0][1] == "test-model"  # model
             assert call_args[0][2] == "en"  # language
+            assert call_args[0][3] == "Custom vocabulary"  # initial_prompt
             assert call_args[1]["debug"] is False
 
     def test_main_with_debug(self, runner: CliRunner) -> None:
@@ -100,6 +104,7 @@ class TestCLI:
                     "WHISPER_URI": "tcp://env-host:8888",
                     "WHISPER_MODEL": "env-model",
                     "WHISPER_LANGUAGE": "fr",
+                    "WHISPER_INITIAL_PROMPT": "Env vocabulary",
                 },
             )
 
@@ -108,3 +113,4 @@ class TestCLI:
             assert call_args[0][0] == "tcp://env-host:8888"
             assert call_args[0][1] == "env-model"
             assert call_args[0][2] == "fr"
+            assert call_args[0][3] == "Env vocabulary"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 """Tests for the server module."""
 
-from unittest.mock import patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from wyoming_mlx_whisper import __version__
 from wyoming_mlx_whisper.const import WHISPER_LANGUAGES
@@ -146,3 +147,44 @@ class TestRunServer:
             # Check that 'auto' was used for language
             calls = " ".join(str(call) for call in mock_logger.info.call_args_list)
             assert "auto" in calls
+
+    def test_passes_initial_prompt_to_handler(self) -> None:
+        """Test that run_server passes the configured initial prompt to handlers."""
+        real_asyncio_run = asyncio.run
+        mock_server = MagicMock()
+        mock_server.run = AsyncMock()
+
+        with (
+            patch("wyoming_mlx_whisper.server._LOGGER"),
+            patch("wyoming_mlx_whisper.server.load_model"),
+            patch(
+                "wyoming_mlx_whisper.server.AsyncServer.from_uri",
+                return_value=mock_server,
+            ),
+            patch("wyoming_mlx_whisper.server.WhisperEventHandler") as mock_handler,
+            patch(
+                "wyoming_mlx_whisper.server.asyncio.run",
+                side_effect=lambda coro, debug: real_asyncio_run(coro, debug=debug),
+            ),
+        ):
+            run_server(
+                uri="tcp://localhost:10300",
+                model="test-model",
+                language="en",
+                initial_prompt="Custom vocabulary",
+                debug=False,
+            )
+
+            mock_server.run.assert_awaited_once()
+            handler_factory = mock_server.run.await_args.args[0]
+            reader = MagicMock()
+            writer = MagicMock()
+            handler_factory(reader, writer)
+
+        mock_handler.assert_called_once()
+        call_args = mock_handler.call_args
+        assert call_args.args[1] == "test-model"
+        assert call_args.args[2] == "en"
+        assert call_args.args[3] == "Custom vocabulary"
+        assert call_args.args[4] is reader
+        assert call_args.args[5] is writer

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -176,7 +176,9 @@ class TestRunServer:
             )
 
             mock_server.run.assert_awaited_once()
-            handler_factory = mock_server.run.await_args.args[0]
+            await_args = mock_server.run.await_args
+            assert await_args is not None
+            handler_factory = await_args.args[0]
             reader = MagicMock()
             writer = MagicMock()
             handler_factory(reader, writer)

--- a/wyoming_mlx_whisper/__main__.py
+++ b/wyoming_mlx_whisper/__main__.py
@@ -28,7 +28,7 @@ DEFAULT_MODEL = "mlx-community/whisper-large-v3-turbo"
 
 
 @app.command()
-def main(
+def main(  # noqa: PLR0913
     uri: Annotated[
         str,
         typer.Option(envvar="WHISPER_URI", help="unix:// or tcp://"),
@@ -40,6 +40,14 @@ def main(
     language: Annotated[
         str | None,
         typer.Option(envvar="WHISPER_LANGUAGE", help="Language code (e.g., 'en')"),
+    ] = None,
+    initial_prompt: Annotated[
+        str | None,
+        typer.Option(
+            "--initial-prompt",
+            envvar="WHISPER_INITIAL_PROMPT",
+            help="Initial prompt to guide Whisper recognition",
+        ),
     ] = None,
     debug: Annotated[  # noqa: FBT002
         bool,
@@ -66,14 +74,15 @@ def main(
         handlers=[RichHandler(rich_tracebacks=True, show_path=debug)],
     )
     _LOGGER.debug(
-        "model=%s, uri=%s, language=%s, debug=%s",
+        "model=%s, uri=%s, language=%s, initial_prompt=%s, debug=%s",
         model,
         uri,
         language,
+        initial_prompt,
         debug,
     )
 
-    run_server(uri, model, language, debug=debug)
+    run_server(uri, model, language, initial_prompt, debug=debug)
 
 
 def run() -> None:

--- a/wyoming_mlx_whisper/handler.py
+++ b/wyoming_mlx_whisper/handler.py
@@ -33,6 +33,7 @@ class WhisperEventHandler(AsyncEventHandler):
         wyoming_info: Info,
         model: str,
         language: str | None,
+        initial_prompt: str | None = None,
         *args: Any,  # noqa: ANN401
         **kwargs: Any,  # noqa: ANN401
     ) -> None:
@@ -40,9 +41,10 @@ class WhisperEventHandler(AsyncEventHandler):
         super().__init__(*args, **kwargs)
         self._model = model
         self._language = language
+        self._default_initial_prompt = initial_prompt
         self._wyoming_info_event = wyoming_info.event()
         self._audio = b""
-        self._initial_prompt: str | None = None
+        self._initial_prompt = initial_prompt
         self._audio_converter = AudioChunkConverter(
             rate=_RATE,
             width=_WIDTH,
@@ -52,7 +54,7 @@ class WhisperEventHandler(AsyncEventHandler):
     def _reset(self) -> None:
         """Reset the audio buffer and transcription context."""
         self._audio = b""
-        self._initial_prompt = None
+        self._initial_prompt = self._default_initial_prompt
 
     def _transcribe(self, audio: NDArray[np.float32]) -> str:
         """Transcribe audio using MLX Whisper."""
@@ -103,8 +105,13 @@ class WhisperEventHandler(AsyncEventHandler):
 
         if Transcribe.is_type(event.type):
             transcribe = Transcribe.from_event(event)
-            if transcribe.context:
-                self._initial_prompt = transcribe.context.get("initial_prompt")
+            if transcribe.context and "initial_prompt" in transcribe.context:
+                initial_prompt = transcribe.context.get("initial_prompt")
+                self._initial_prompt = (
+                    initial_prompt
+                    if isinstance(initial_prompt, str) and initial_prompt
+                    else self._default_initial_prompt
+                )
                 if self._initial_prompt:
                     _LOGGER.debug("Using initial prompt: %s", self._initial_prompt)
             _LOGGER.debug("Transcribe event")

--- a/wyoming_mlx_whisper/server.py
+++ b/wyoming_mlx_whisper/server.py
@@ -50,6 +50,7 @@ def run_server(
     uri: str,
     model: str,
     language: str | None,
+    initial_prompt: str | None = None,
     *,
     debug: bool,
 ) -> None:
@@ -73,6 +74,7 @@ def run_server(
                 wyoming_info,
                 model,
                 language,
+                initial_prompt,
                 *args,
                 **kwargs,
             ),


### PR DESCRIPTION
## Summary
- Add --initial-prompt with WHISPER_INITIAL_PROMPT support.
- Pass the configured prompt through server startup into WhisperEventHandler.
- Preserve request-level initial_prompt context overrides and reset back to the configured default between requests.
- Update README option docs.

Closes #15

## Test Plan
- uv run ruff format --check .
- uv run ruff check .
- uv run mypy wyoming_mlx_whisper
- uv run pytest